### PR TITLE
Update .gitignore, add compose.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore dynamically generated database
+database.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  zulip-bot-kuechendienst:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: zulip-bot-kuechendienst
+    volumes:
+      - ./database.json:/database.json
+    restart: unless-stopped


### PR DESCRIPTION
Previously, the `.gitignore` did not list the automatically generated `database.json`. 
Since you would not want to commit this, we added the respective line.

Furthmore, this PR adds a `compose.yaml` for easier deployment (`sudo docker compose up`, instead of running manually). 